### PR TITLE
Make the Tombstone `undefined`

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,10 @@ function get (key) {
 
 function put (createValue, key, val) {
   checkKey(key)
+  
+  if (val === undefined) {
+    throw new Error('cannot varhash.put(key, undefined).')
+  }
 
   var observ = createValue(val, key)
   var state = extend(this())


### PR DESCRIPTION
Having a Tombstone value makes it complicated to detect deletes.

We can use `undefined` instead.

`undefined` is not JSON serializable. It's safe to use this value since `observ-varhash` should be serializable.

If someone does `varhash.put(key, undefined)` we could throw.
