### PR TITLE
Avoid sync race condition.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,8 @@ function put (createValue, key, val) {
 
   setNonEnumerable(state, '_diff', diff(key, state[key]))
 
-  this.set(state)
   this[key] = observ
+  this.set(state)
 
   return this
 }


### PR DESCRIPTION
We must finish mutating ourself before we call event listeners.

If an event listener access `varhash.foo` it should work.
