### PR TITLE
Make methods non enumerable

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function ObservVarhash (hash, createValue) {
   var obs = Observ(initialState)
   setNonEnumerable(obs, '_removeListeners', {})
 
+  setNonEnumerable(obs, 'set', obs.set)
   setNonEnumerable(obs, 'get', get.bind(obs))
   setNonEnumerable(obs, 'put', put.bind(obs, createValue))
   setNonEnumerable(obs, 'delete', del.bind(obs))


### PR DESCRIPTION
This means you can call `Object.keys(varhash)` and get the actual keys, not the keys + methods.
