### PR TITLE
Wrap blacklist's delete property in quotes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ var blacklist = {
   name: 'Clashes with `Function.prototype.name`.',
   get: 'get is a reserved key of observ-varhash method',
   put: 'put is a reserved key of observ-varhash method',
-  delete: 'delete is a reserved key of observ-varhash method',
+  'delete': 'delete is a reserved key of observ-varhash method',
   _diff: '_diff is a reserved key of observ-varhash method',
   _removeListeners: '_removeListeners is a reserved key of observ-varhash'
 }


### PR DESCRIPTION
Delete is a reserved keyword in JS, so IE8 complains about its bare usage here. Normally, none of this stuff would work at all in IE8, but this one change is all that's required for it to work alongside a polyfill like es5shim.