### PR TITLE
Make `set` non-enumerable again

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function ObservVarhash (hash, createValue) {
 
     _set(newState)
   }
+  setNonEnumerable(obs, 'set', obs.set)
 
   var newState = {}
   for (key in hash) {


### PR DESCRIPTION
Fixes #20 and makes `set` non-enumerable.
